### PR TITLE
fix: use request.get_data() instead of request.data to fix reading issue

### DIFF
--- a/2.root/app.py
+++ b/2.root/app.py
@@ -18,7 +18,7 @@ def home():
 
 @app.route("/upload", methods=["POST"])
 def upload():
-    data = request.data
+    data = request.get_data()
 
     try:
         obj = pickle.loads(data)


### PR DESCRIPTION
Fix an issue where flask wouldn't get the data sent in the request.

Error stack:
```
  File "/home/yvan/School/formation-lab-docker-secu/2.root/lib/python3.13/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/yvan/School/formation-lab-docker-secu/2.root/lib/python3.13/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/yvan/School/formation-lab-docker-secu/2.root/lib/python3.13/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/yvan/School/formation-lab-docker-secu/2.root/lib/python3.13/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/yvan/School/formation-lab-docker-secu/2.root/app.py", line 25, in upload
    obj = pickle.loads(data)
EOFError: Ran out of input
Taille des données reçues : 0 octets
Début des données : b''
```

